### PR TITLE
Fix regex and color parsing

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -3,7 +3,7 @@ import sass from 'node-sass';
 const REGEX_VARIABLE_GLOBAL_IMPLICIT = /(\$[\w-_]+)\s*:\s*((.*?[\r\n]?)+?);/g;
 const REGEX_VARIABLE_GLOBAL_EXPLICIT = /(\$[\w-_]+)\s*:\s*(.*?)\s+!global\s*;/g;
 const REGEX_DEEP_CONTEXT = /({[^{}]*})/g;
-const REGEX_COMMENTS = /(?:(?:\/\*[\w\W]*\*\/)|(?:\/\/[^\r\n]*[\r\n]?))/g;
+const REGEX_COMMENTS = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g;
 
 /**
  * Strip a string for all occurences that matches provided regex

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,9 +1,9 @@
 import sass from 'node-sass';
 
-const REGEX_VARIABLE_GLOBAL_IMPLICIT = /(\$[\w-_]+)\s*:\s*((.*?[\r\n]?)+?);/g;
+const REGEX_VARIABLE_GLOBAL_IMPLICIT = /(\$[\w-]+)\s*:\s*(.+?|(.*[\r\n])*\s*\));/g;
 const REGEX_VARIABLE_GLOBAL_EXPLICIT = /(\$[\w-_]+)\s*:\s*(.*?)\s+!global\s*;/g;
 const REGEX_DEEP_CONTEXT = /({[^{}]*})/g;
-const REGEX_COMMENTS = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g;
+const REGEX_COMMENTS = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|(\/\/.*)/g;
 
 /**
  * Strip a string for all occurences that matches provided regex

--- a/src/struct.js
+++ b/src/struct.js
@@ -4,7 +4,7 @@ import sass from 'node-sass';
  * Convert a color value 0-255 to hex 00-FF
  */
 function toColorHex(value) {
-  let colorHex = value.toString(16);
+  let colorHex = Math.round(value).toString(16);
 
   if(colorHex.length < 2) {
     colorHex = `0${colorHex}`;
@@ -36,7 +36,7 @@ function makeValue(sassValue) {
         },
       };
 
-    case sass.types.Null: 
+    case sass.types.Null:
       return { value: null };
 
     case sass.types.List:
@@ -64,7 +64,7 @@ function makeValue(sassValue) {
  * Create a structured value definition from a sassValue object
  */
 export function createStructuredValue(sassValue) {
-  const value = Object.assign({ 
+  const value = Object.assign({
     type: sassValue.constructor.name,
   }, makeValue(sassValue));
 


### PR DESCRIPTION
Ahoy!

I fixed the problem with the multiline comments #14 and a not ending regex.

The not ending regex occurred when parsing bootstrap 4. They used default parameters in functions which killed the variable regex.

I also fixed parsing hex colors from colors with fractional portions which ended up like `#64.6e147ae147b96.3ae147ae1478a.b33333333333` before;

My Sass code with bootstrap 4 dependency seems to work fine now 👍  

### Old regex
```js
const REGEX_COMMENTS = /(?:(?:\/\*[\w\W]*\*\/)|(?:\/\/[^\r\n]*[\r\n]?))/g;
const REGEX_VARIABLE_GLOBAL_IMPLICIT = /(\$[\w-_]+)\s*:\s*((.*?[\r\n]?)+?);/g;
```

### New regex 
```js
const REGEX_COMMENTS = /(\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\/)|(\/\/.*)/g;
const REGEX_VARIABLE_GLOBAL_IMPLICIT = /(\$[\w-]+)\s*:\s*(.+?|(.*[\r\n])*\s*\));/g;
```

### Test Scss for regex
```scss
$match: 'ahoy';
$match_me: 'hey';
$match-me-again: 'hello';

// Wrong matching
@function color($key: "blue") {
  @return map-get($colors, $key);
}

@function theme-color($key: "primary") {
  @return map-get($theme-colors, $key);
}

// Provoke timeout
@function stuck($key: "test") {
	// no semicolon here
}
```