### PR TITLE
feat(struct): add separator info to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ $variable: 1px solid black;
 ```js
 {
   type: 'SassList',
+  commaSeparator: false,
   value: [
     {
       type: 'SassNumber',
@@ -376,6 +377,28 @@ $variable: 1px solid black;
         a: 1,
         hex: '#000000'
       }
+    }
+  ]
+}
+```
+
+*Or when it's comma separated*
+
+```scss
+$variable: tahoma, arial;
+```
+```js
+{
+  type: 'SassList',
+  commaSeparator: true,
+  value: [
+    {
+      type: 'SassString',
+      value: 'tahoma'
+    },
+    {
+      type: 'SassString',
+      value: 'arial'
     }
   ]
 }

--- a/src/struct.js
+++ b/src/struct.js
@@ -27,7 +27,7 @@ function makeValue(sassValue) {
         },
       };
 
-    case sass.types.Null: 
+    case sass.types.Null:
       return { value: null };
 
     case sass.types.List:
@@ -36,7 +36,7 @@ function makeValue(sassValue) {
       for(let i = 0; i < listLength; i++) {
         listValue.push(createStructuredValue(sassValue.getValue(i)));
       }
-      return { value: listValue };
+      return { value: listValue, commaSeparator: sassValue.getSeparator() };
 
     case sass.types.Map:
       const mapLength = sassValue.getLength();
@@ -57,7 +57,7 @@ function makeValue(sassValue) {
  * Create a structured value definition from a sassValue object
  */
 export function createStructuredValue(sassValue) {
-  const value = Object.assign({ 
+  const value = Object.assign({
     type: sassValue.constructor.name,
   }, makeValue(sassValue));
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -15,6 +15,7 @@ function verifyBasic(rendered, sourceFile, explicit, mixed) {
   expect(rendered.vars.global).to.have.property('$number2');
   expect(rendered.vars.global).to.have.property('$color');
   expect(rendered.vars.global).to.have.property('$list');
+  expect(rendered.vars.global).to.have.property('$listComma');
   expect(rendered.vars.global).to.have.property('$string');
   expect(rendered.vars.global).to.have.property('$boolean');
   expect(rendered.vars.global).to.have.property('$null');
@@ -72,9 +73,25 @@ function verifyBasic(rendered, sourceFile, explicit, mixed) {
   expect(rendered.vars.global.$list.value[2].value.b).to.equal(0);
   expect(rendered.vars.global.$list.value[2].value.a).to.equal(1);
   expect(rendered.vars.global.$list.value[2].value.hex).to.equal('#000000');
-  expect(rendered.vars.global.$list.value[2].type).to.equal('SassColor'); 
+  expect(rendered.vars.global.$list.value[2].type).to.equal('SassColor');
+  expect(rendered.vars.global.$list.commaSeparator).to.equal(false);
   if(explicit) {
     expect(rendered.vars.global.$list.declarations[0].flags.global).to.equal(true);
+  }
+
+  expect(rendered.vars.global.$listComma.value).to.have.length(2);
+  expect(rendered.vars.global.$listComma.type).to.equal('SassList');
+  expect(rendered.vars.global.$listComma.sources).to.have.length(1);
+  expect(rendered.vars.global.$listComma.sources[0]).to.equal(normalizePath(sourceFile));
+  expect(rendered.vars.global.$listComma.declarations).to.have.length(1);
+  expect(rendered.vars.global.$listComma.declarations[0].expression).to.equal(`tahoma, arial${ explicit ? ' !global' : ''}`);
+  expect(rendered.vars.global.$listComma.value[0].value).to.equal('tahoma');
+  expect(rendered.vars.global.$listComma.value[0].type).to.equal('SassString');
+  expect(rendered.vars.global.$listComma.value[1].value).to.equal('arial');
+  expect(rendered.vars.global.$listComma.value[1].type).to.equal('SassString');
+  expect(rendered.vars.global.$listComma.commaSeparator).to.equal(true);
+  if(explicit) {
+    expect(rendered.vars.global.$listComma.declarations[0].flags.global).to.equal(true);
   }
 
   expect(rendered.vars.global.$string.value).to.equal('string');

--- a/test/sass/basic-explicit.scss
+++ b/test/sass/basic-explicit.scss
@@ -7,6 +7,7 @@ div {
   $number2: $number1 * 2 !global;
   $color: get-color() !global;
   $list: 1px solid black !global;
+  $listComma: tahoma, arial !global;
   $string: 'string' !global;
   $boolean: true !global;
   $null: null !global;

--- a/test/sass/basic-implicit.scss
+++ b/test/sass/basic-implicit.scss
@@ -6,6 +6,7 @@ $number1: 100px;
 $number2: $number1 * 2;
 $color: get-color();
 $list: 1px solid black;
+$listComma: tahoma, arial;
 $string: 'string';
 $boolean: true;
 $null: null;

--- a/test/sass/basic-mixed.scss
+++ b/test/sass/basic-mixed.scss
@@ -11,6 +11,7 @@
 
 
 $list: 1px solid black;
+$listComma: tahoma, arial;
 $string: 'string';
 $map: (
   number: 2em,

--- a/test/sass/comments.scss
+++ b/test/sass/comments.scss
@@ -3,6 +3,7 @@ $number1: 100px;
 $number2: $number1 * 2; // Comment
 $color: red;
 /* $list: 1px solid black;
+$listComma: tahoma, arial;
 $string: 'string';
 $map: (
   number: 2em,


### PR DESCRIPTION
During struct info about separator type in list is removed.
It could be restored using plugin in postValue stage, but only on top level list variables, not in nested ones.