### PR TITLE
Allow custom importers.

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -95,7 +95,7 @@ export function extract(rendered, { compileOptions = {}, extractOptions = {} } =
   .then(({ compiledFiles, orderedFiles }) => {
     const parsedDeclarations = parseFiles(compiledFiles);
     const extractions = processFiles(orderedFiles, compiledFiles, parsedDeclarations, pluggable);
-    const importer = makeImporter(extractions, includedFiles, includedPaths);
+    const importer = makeImporter(extractions, includedFiles, includedPaths, compileOptions.importer);
     const extractionCompileOptions = makeExtractionCompileOptions(compileOptions, entryFilename, extractions, importer);
 
     return sass.renderAsync(extractionCompileOptions)
@@ -117,7 +117,7 @@ export function extractSync(rendered, { compileOptions = {}, extractOptions = {}
   const { compiledFiles, orderedFiles } = loadCompiledFilesSync(includedFiles, entryFilename, compileOptions.data);
   const parsedDeclarations = parseFiles(compiledFiles);
   const extractions = processFiles(orderedFiles, compiledFiles, parsedDeclarations, pluggable);
-  const importer = makeSyncImporter(extractions, includedFiles, includedPaths);
+  const importer = makeSyncImporter(extractions, includedFiles, includedPaths, compileOptions.importer);
   const extractionCompileOptions = makeExtractionCompileOptions(compileOptions, entryFilename, extractions, importer);
 
   sass.renderSync(extractionCompileOptions);

--- a/test/include.js
+++ b/test/include.js
@@ -6,6 +6,7 @@ const { normalizePath } = require('../src/util');
 const includeRootFile = path.join(__dirname, 'sass', 'include', 'root.scss');
 const includeRoot2File = path.join(__dirname, 'sass', 'include', 'root2.scss');
 const includeRoot3File = path.join(__dirname, 'sass', 'include', 'root3.scss');
+const includeRoot4File = path.join(__dirname, 'sass', 'include', 'root4.scss');
 const includeSubFile = path.join(__dirname, 'sass', 'include', 'sub', 'included.scss');
 const includeSubFile2 = path.join(__dirname, 'sass', 'include', 'sub', 'included2.scss');
 const includeSubDir = path.join(__dirname, 'sass', 'include', 'sub');
@@ -262,6 +263,66 @@ describe('include', () => {
           .then(rendered => {
             verifyFunctions(rendered, includeRoot3File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
           });
+        });
+      });
+    });
+  });
+
+  describe('custom importer', () => {
+    const getNewUrl = url => url === 'foo' ? './included.scss' : url;
+
+    describe('sync', () => {
+      it('should extract all variables', () => {
+        const rendered = renderSync({ file: includeRoot4File, includePaths: [includeSubDir], importer: url => ({ file: getNewUrl(url) }) });
+        verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
+      });
+    });
+
+    describe('async', () => {
+      it('should extract all variables', () => {
+        return render({ file: includeRoot4File, includePaths: [includeSubDir], importer: (url, prev, done) => { done({ file: getNewUrl(url) }); } })
+        .then(rendered => {
+          verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
+        });
+      });
+    });
+  });
+
+  describe('array of custom importers', () => {
+    const getNewUrl = url => url === 'foo' ? './included.scss' : url;
+
+    describe('sync', () => {
+      it('should extract all variables', () => {
+        const rendered = renderSync({ file: includeRoot4File, includePaths: [includeSubDir], importer: [() => null, url => ({ file: getNewUrl(url) })] });
+        verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
+      });
+    });
+
+    describe('async', () => {
+      it('should extract all variables', () => {
+        return render({ file: includeRoot4File, includePaths: [includeSubDir], importer: [(url, prev, done) => { done(null); }, (url, prev, done) => { done({ file: getNewUrl(url) }); }] })
+        .then(rendered => {
+          verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
+        });
+      });
+    });
+  });
+
+  describe('absolute include path', () => {
+    const getNewUrl = url => url === 'foo' ? path.join(__dirname, 'sass', 'include', 'sub', 'included.scss') : url;
+
+    describe('sync', () => {
+      it('should extract all variables', () => {
+        const rendered = renderSync({ file: includeRoot4File, importer: url => ({ file: getNewUrl(url) }) });
+        verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
+      });
+    });
+
+    describe('async', () => {
+      it('should extract all variables', () => {
+        return render({ file: includeRoot4File, importer: (url, prev, done) => { done({ file: getNewUrl(url) }); } })
+        .then(rendered => {
+          verifyFunctions(rendered, includeRoot4File, SUB_INCLUDED_COLOR, SUB_INCLUDED2_COLOR, includeSubFile,  includeSubFile2);
         });
       });
     });

--- a/test/sass/include/root4.scss
+++ b/test/sass/include/root4.scss
@@ -1,0 +1,2 @@
+@import 'foo';
+$color: $includedColor;


### PR DESCRIPTION
Fixes #24.

If a user passes in a custom `importer` option, this PR now passes that option through to `node-sass`. It also modifies the sass-extract specific `importer` to preprocess the filepath through any custom importers first.
 
`node-sass` accepts both sync and async versions of `importer` fns, and also accepts an array of fns or a single fn. This PR supports (and tests) all of those cases.

If the user, however, has an `importer` fn which returns `{ contents: <...> }` (instead of `{ file: <...> }`), that is _not_ supported. It will still pass through to node-sass (so the files can be compiled properly), but sass-extract won't be able to extract variables from those imports. I think those would be unusable by sass-extract in any case?