### PR TITLE
Fix `renderSync` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A synchronous version of the `render` function.
 ```js
 const sassExtract = require('sass-extract');
 
-const rendered = sassExtract.render({
+const rendered = sassExtract.renderSync({
   file: 'path/to/my/styles.scss'
 });
 


### PR DESCRIPTION
The example for `renderSync` should use `renderSync`, not `render` :)