### PR TITLE
refactor(importer): importer functions should always call a callback instead of returning a Promise.

### DIFF
--- a/src/importer.js
+++ b/src/importer.js
@@ -94,6 +94,10 @@ export function makeImporter(extractions, includedFiles, includedPaths, customIm
     try {
       const promises = [];
       if (customImporter) {
+        if (!Array.isArray(customImporter)) {
+          customImporter = [customImporter]
+        }
+
         customImporter.forEach(importer => {
           promises.push(new Promise(res => {
             importer(url, prev, (value) => res(value));


### PR DESCRIPTION
BREAKING CHANGE: Compatibility with node-sass: importers so far had to either call a callback (when they're called in the rendering phase, by `node-sass`) or return a Promise (when they're called in the extracting phase, by `makeImporter()`). From now, importers should always call the callback function provided in the third parameter of the importer function.

fix #36