### PR TITLE
Changes the method `getImportAbsolutePath` normalize the URL when finding the import's path

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "node-sass": "^3.8.0"
+    "node-sass": "^3.8.0 || 4"
   },
   "dependencies": {
     "bluebird": "^3.4.7",
@@ -43,7 +43,7 @@
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
     "cz-conventional-changelog": "^2.1.0",
-    "foundation-sites": "~6.4.3",
+    "foundation-sites": "^6.4.3",
     "mocha": "^4.0.1"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "node-sass": "^3.8.0 || 4"
+    "node-sass": "^3.0.0"
   },
   "dependencies": {
     "bluebird": "^3.4.7",
@@ -43,7 +43,7 @@
     "chai": "^4.1.2",
     "chai-subset": "^1.6.0",
     "cz-conventional-changelog": "^2.1.0",
-    "foundation-sites": "^6.4.3",
+    "foundation-sites": "~6.4.3",
     "mocha": "^4.0.1"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "node-sass": "^3.0.0"
+    "node-sass": "^3.8.0"
   },
   "dependencies": {
     "bluebird": "^3.4.7",

--- a/src/importer.js
+++ b/src/importer.js
@@ -58,7 +58,7 @@ function getImportAbsolutePath(url, prev, includedFilesMap, includedPaths = []) 
     url += extension;
   }
 
-  const absolutePath = findImportedPath(url, prev, includedFilesMap, includedPaths);
+  const absolutePath = findImportedPath(normalizePath(url), prev, includedFilesMap, includedPaths);
 
   if(!absolutePath) {
     throw new Error(`Can not determine imported file for url '${url}' imported in ${prev}`);


### PR DESCRIPTION
#### What does this PR do:

* Changes the method `getImportAbsolutePath` to pass the `url` normalized to the `findImportedPath` to solve paths' issues on Windows coming from importers

#### Where should the reviewer start:

* Diffs

Fixes #41 