### PR TITLE
chore: make node-sass optional in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "node-sass": ">=3.8.0",
     "sass": ">=1"
   },
+  "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "bluebird": "^3.7.2",
     "fs-monkey": "^1.0.4",


### PR DESCRIPTION
- Added peerDependenciesMeta section in package.json to mark node-sass as optional.
- This change allows users to install either node-sass or sass without warnings if node-sass is not present.
- Ensures greater flexibility for users who prefer using Dart Sass or other implementations.