### PR TITLE
Make node-sass optional in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "query-ast": "^1.0.2"
   },
   "devDependencies": {
+    "node-sass": ">=3.8.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "node-sass": ">=3.8.0",
     "sass": ">=1"
   },
+  "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "bluebird": "^3.7.2",
     "fs-monkey": "^1.0.4",


### PR DESCRIPTION
- Added peerDependenciesMeta section in package.json to mark node-sass as optional.
- This change allows users to install either node-sass or sass without warnings if node-sass is not present.
- Ensures greater flexibility for users who prefer using Dart Sass or other implementations.